### PR TITLE
Make healthcheck URL configurable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,6 @@
 # General
 NEXT_PUBLIC_URL = foo
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000
 
 # Service X Secrets
 SERVICE_USER=foo

--- a/README.md
+++ b/README.md
@@ -44,3 +44,10 @@ Start building modern web applications using React and Next.js.
 - Jest for unit testing and Testing Library React for testing React components.
 - Playwright for end-to-end testing.
 - MSW for API mocking.
+
+## Environment variables
+
+Use `NEXT_PUBLIC_API_BASE_URL` to set a base URL for API requests. The value
+is exported as `apiBaseUrl` from `@/lib/misc/environment` and can be reused
+throughout the codebase. If the variable is not defined, requests fall back to
+relative paths such as `/api/healthcheck`.

--- a/app/lib/hooks/useHealthcheck.ts
+++ b/app/lib/hooks/useHealthcheck.ts
@@ -1,11 +1,13 @@
 import { useQuery } from '@tanstack/react-query'
 
+import { apiBaseUrl } from '@/lib/misc/environment'
+
 export const useHealthcheck = () => {
   return useQuery({
     queryKey: ['healthcheck'],
     queryFn: async () => {
-      return await fetch('http://localhost:3000/api/healthcheck').then(
-        (response) => response.json()
+      return await fetch(`${apiBaseUrl}/api/healthcheck`).then((response) =>
+        response.json()
       )
     },
   })

--- a/app/lib/misc/environment.ts
+++ b/app/lib/misc/environment.ts
@@ -13,3 +13,5 @@ export const isServer = () => {
 export const isClient = () => {
   return !isServer()
 }
+
+export const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL ?? ''

--- a/app/lib/mocks/handlers.ts
+++ b/app/lib/mocks/handlers.ts
@@ -1,6 +1,6 @@
 import { HttpResponse, http } from 'msw'
 
-const healthcheckHandler = http.get('http://localhost:3000/healthcheck', () => {
+const healthcheckHandler = http.get('/api/healthcheck', () => {
   return HttpResponse.json(
     {
       message: 'ok',


### PR DESCRIPTION
## Summary
- make healthcheck hook use `NEXT_PUBLIC_API_BASE_URL`
- update MSW handler path
- document API base URL environment variable
- update env sample
- export `apiBaseUrl` constant in `environment.ts`
- use `apiBaseUrl` in `useHealthcheck` hook

## Testing
- `pnpm lint:js --fix`
- `pnpm test:unit`
